### PR TITLE
Fix undefined format-to-string errors

### DIFF
--- a/client/tests/http-client-test-suite-library.dylan
+++ b/client/tests/http-client-test-suite-library.dylan
@@ -13,7 +13,7 @@ define library http-client-test-suite
   use testworks;
   use uri;
   use strings;
-  use io, import: { format-out, streams };
+  use io, import: { format, streams };
 
   export http-client-test-suite;
 end library http-client-test-suite;
@@ -31,7 +31,7 @@ define module http-client-test-suite
   use uri;
   use streams;
   use strings;
-  use format-out;
+  use format;
 
   export http-client-test-suite;
 end module http-client-test-suite;

--- a/tests/http-testing-library.dylan
+++ b/tests/http-testing-library.dylan
@@ -8,11 +8,13 @@ define library http-testing
   use http-server;
   use logging;
   use uri;
+  use io, import: { format };
 
   export http-testing;
 end library http-testing;
 
 define module http-testing
+  use format;
   use common-dylan;
   use http-client;
   use http-common;


### PR DESCRIPTION
A couple of files were referencing format-to-string without having it
imported and available. This change makes it available.

tests/http-testing.dylan:88: Serious warning - Reference to undefined
binding {format-to-string in http-testing}.

```
----------------
  test-url(format-to-string("/x?n=%d", n))
----------------
```

client/tests/http-client-test-suite.dylan:287: Serious warning -
Reference to undefined binding {format-to-string in
http-client-test-suite}.

```
----------------
  check-equal(format-to-string("chunked request of size %d received correctly",
----------------
```
