### PR TITLE
Invoke specialized write for <response>

### DIFF
--- a/server/core/response.dylan
+++ b/server/core/response.dylan
@@ -96,6 +96,14 @@ define sealed inline method write
   maybe-send-chunk(response);
 end method write;
 
+define sealed inline method write
+    (response :: <response>, chars :: <sequence>,
+     #key start: bpos = 0, end: epos)
+ => ()
+  write(response.response-stream, chars, start: bpos, end: epos);
+  maybe-send-chunk(response);
+end method write;
+
 // Send a chunk if this is a chunked response and the chunk buffer is full.
 // Note that if this is not a chunked response we do nothing, so the entire
 // response is buffered.


### PR DESCRIPTION
The `<response>` type has a specialized version of `write` and `write-element` defined in `server/core/response.dylan` for `<response>` and `<byte-string>`, but `copy-to-end` here instead called a more generic version for `<stream>` and `<sequence>`.

This meant the `<response>` was being written to as a normal stream, instead of using the `maybe-send-chunk` method and writing to `response.response-stream`.

Coercing the parameters to the types expected by the `write` and `write-element` methods in `server/core/response.dylan` fixes an issue with `<directory-resource>` serving static files.
