### PR TITLE
change raw-headers to response-headers

### DIFF
--- a/server/core/static-files.dylan
+++ b/server/core/static-files.dylan
@@ -105,7 +105,7 @@ define method respond-to-get
     let client-etag = get-header(request, "If-None-Match");
     if (etag = client-etag)
       request.request-method := #"head";
-      not-modified-redirect(headers: response.raw-headers);
+      not-modified-redirect(headers: response.response-headers);
     else
       serve-static-file(policy, document);
     end;


### PR DESCRIPTION
`<response>` has no slot `raw-headers`

d3320d53c5f5443c5a75f56ebbc0935833fc04c3 changed an instance of `raw-headers` to `response-headers`, it seems like this should be the same.

Caused an issue with `debug: #t` on `<http-server>` since the getter was undefined.
