### PR TITLE
[http-server] Remove HTTP/0.9 support.

### DIFF
--- a/common/http-common.dylan
+++ b/common/http-common.dylan
@@ -79,7 +79,6 @@ define method validate-http-version
   else
     // Take care not to intern arbitrary symbols...
     select (version by string-equal?)
-      "HTTP/0.9" => #"HTTP/0.9";
       "HTTP/1.0" => #"HTTP/1.0";
       "HTTP/1.1" => #"HTTP/1.1";
       otherwise =>

--- a/server/core/request.dylan
+++ b/server/core/request.dylan
@@ -113,12 +113,10 @@ define method read-request
   end;
 
   parse-request-line(server, request, buffer, len);
-  unless (request.request-version == #"http/0.9")
-    read-message-headers(socket,
-                         buffer: buffer,
-                         start: len,
-                         headers: request.raw-headers);
-  end unless;
+  read-message-headers(socket,
+                       buffer: buffer,
+                       start: len,
+                       headers: request.raw-headers);
   process-incoming-headers(request);
   // Unconditionally read all request content in case we need to process
   // further requests on the same connection.  This is temporary and needs

--- a/server/tests/request-tests.dylan
+++ b/server/tests/request-tests.dylan
@@ -23,8 +23,7 @@ define test test-parse-request-line-values ()
     // http-version tests
     list("GET http://foo HTTP/1.1", #"get", "http://foo", #"http/1.1"),
     list("GET url HTTP/1.0", #"get", "url", #"http/1.0"),
-    // not yet
-    //list("GET url HTTP/0.9", <http-version-not-supported-error>),
+    list("GET url HTTP/0.9", <http-version-not-supported-error>),
     list("GET url http/1.x", <bad-request-error>),
 
     // other tests


### PR DESCRIPTION
This was broken anyway and is no longer required.
