### PR TITLE
Fix bugs in http-client discovered by Piotr Klibert

### DIFF
--- a/common/http-common.dylan
+++ b/common/http-common.dylan
@@ -3,13 +3,6 @@ Synopsis: Code shared by HTTP client and server.
 Copyright: See LICENSE in this distribution for details.
 
 
-define constant $http-version :: <byte-string> = "HTTP/1.1";
-
-define constant $default-http-port :: <integer> = 8000;
-
-define constant $default-https-port :: <integer> = 8443;
-
-
 // By the spec request methods are case-sensitive, but for convenience
 // we let them be specified as symbols as well.  If a symbol is used it
 // is uppercased before sending to the server.  Similarly for HTTP version.

--- a/common/library.dylan
+++ b/common/library.dylan
@@ -35,9 +35,6 @@ end library http-common;
 
 define module http-common
   create
-    $http-version,
-    $default-http-port,
-    $default-https-port,
     <request-method>,
     <http-version>,
     *http-common-log*,

--- a/documentation/source/reference/common.rst
+++ b/documentation/source/reference/common.rst
@@ -22,10 +22,6 @@ The HTTP-COMMON module
 
 .. constant:: $default-cookie-version
 
-.. constant:: $default-http-port
-
-.. constant:: $default-https-port
-
 .. constant:: $expectation-failed-error
 
 .. constant:: $forbidden-error
@@ -37,8 +33,6 @@ The HTTP-COMMON module
 .. constant:: $gone-error
 
 .. constant:: $header-too-large-error
-
-.. constant:: $http-version
 
 .. constant:: $http-version-not-supported-error
 

--- a/server/core/command-line.dylan
+++ b/server/core/command-line.dylan
@@ -14,7 +14,7 @@ add-option(*command-line-parser*,
                                        "listen.  Option may be "
                                        "repeated. "
                                        "[default: 0.0.0.0:%d]",
-                                     $default-http-port),
+                                       $default-http-port),
                 names: #("listen", "l")));
 
 // --config <file>

--- a/server/core/utilities.dylan
+++ b/server/core/utilities.dylan
@@ -4,6 +4,11 @@ Copyright: See LICENSE in this distribution for details.
 Synopsis:  Variables and utilities 
 
 
+define constant $http-version :: <byte-string> = "HTTP/1.1";
+define constant $default-http-port :: <integer> = 8000;
+define constant $default-https-port :: <integer> = 8443;
+
+
 // Command-line arguments parser.  The expectation is that libraries that use
 // and extend this server (e.g., wiki) may want to add their own <option-parser>s to
 // this before calling http-server-main().


### PR DESCRIPTION
- $default-http[s]-port shouldn't be the same for client and server, so I
  removed it from http-common and instead use unexported constants in server
  and client.  Client gets 80 and 443, server gets 8000 and 8443.  Eventually
  the client shouldn't need these constants since the uri library should supply
  defaults for schemes that specify them.
- Default read-response-body? to #t in http-request(<string>, <request-method>).
- Use parse-url instead of parse-uri in http-request because
  <base-http-request> expects a <url>.  This may not be the correct long-term
  fix though.  Will look into getting rid of the <url> class completely and
  just have <uri>.
