### PR TITLE
exporting response-headers; useful for wiki and web-framework

### DIFF
--- a/server/core/library.dylan
+++ b/server/core/library.dylan
@@ -119,6 +119,7 @@ define module http-server
     <response>,
     // See also: methods on <base-http-response> in common-dylan.
     current-response,            // Returns the active response of the thread.
+    response-headers,
     output,
     add-cookie;
 


### PR DESCRIPTION
@cgay says that `<response>` could inherit from `<message-headers-mixin>`; for now this serves my purposes ...
