### PR TITLE
CI: don't run make linkcheck

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -27,12 +27,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Check links
-        uses: addnab/docker-run-action@v3
-        with:
-          image: ghcr.io/fraya/dylan-docs
-          options: -v ${{ github.workspace }}/documentation:/docs
-          run: make linkcheck
+      # Doesn't work due to http://127.0.0.1 links in the docs.
+      # - name: Check links
+      #   uses: addnab/docker-run-action@v3
+      #   with:
+      #     image: ghcr.io/fraya/dylan-docs
+      #     options: -v ${{ github.workspace }}/documentation:/docs
+      #     run: make linkcheck
 
       - name: Build docs with Furo theme
         uses: addnab/docker-run-action@v3


### PR DESCRIPTION
Make linkcheck doesn't work due to http://127.0.0.1 links in the docs.