### PR TITLE
package: use latest versions of testworks and sphinx-extensions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,7 +1,7 @@
-# For now this just does a clean build because the test suites hang.
-# https://github.com/dylan-lang/http/issues/90
+# For now this just does a clean build and start/stop the server because the test suites
+# hang.  https://github.com/dylan-lang/http/issues/90
 
-name: test-suite
+name: tests
 
 on:
   push:
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dylan-lang/install-dylan-tool@v3
+      - uses: dylan-lang/install-opendylan@v3
 
       - name: make install
         env:
@@ -33,4 +33,8 @@ jobs:
       - name: Run http-server --help
         env:
           DYLAN: dylan-root
-        run: dylan-root/bin/http-server --help
+          LD_LIBRARY_PATH: _od/opendylan-2024.1/lib
+        run: |
+          ls -l dylan-root/bin/
+          find . -name '*unwind*'
+          dylan-root/bin/http-server --help

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
-# The impetus for this Makefile was to include Git version info in the
-# generated executable and to install http-server-app as a static executable
-# named simply "http-server".
-#
-# The expectation is that during development people will use `dylan build
-# --all` or similar to build libraries.
+# The impetus for this Makefile was to include Git version info in the generated
+# executable and to install http-server-app as a static executable named simply
+# "http-server". The expectation is that during development people will use `deft build`
+# or `deft test`.
+
+# TODO: use the .gitattributes filtering that Deft uses instead of this version hack.
 
 DYLAN		?= $${HOME}/dylan
 

--- a/dylan-package.json
+++ b/dylan-package.json
@@ -13,8 +13,8 @@
         "xml-parser@0.2.1"
     ],
     "dev-dependencies": [
-        "testworks@2.1",
-        "sphinx-extensions@0.2"
+        "testworks",
+        "sphinx-extensions"
     ],
     "url": "https://github.com/dylan-lang/http",
     "version": "1.1.2"


### PR DESCRIPTION
Less likely to cause dependency conflicts