### PR TITLE
build: Better Git version info hack, don't --unify

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,13 +28,10 @@ jobs:
       - name: make install
         env:
           DYLAN: dylan-root
-        run: make install
+        run: |
+          deft update
+          make install
 
       - name: Run http-server --help
-        env:
-          DYLAN: dylan-root
-          LD_LIBRARY_PATH: _od/opendylan-2024.1/lib
         run: |
-          ls -l dylan-root/bin/
-          find . -name '*unwind*'
           dylan-root/bin/http-server --help

--- a/server/core/server.dylan
+++ b/server/core/server.dylan
@@ -8,12 +8,8 @@ Copyright: See LICENSE in this distribution for details.
 // sort of connotes slowness (?) so I stopped using it.
 define constant $server-name = "Dylan HTTP Server";
 
-// The Makefile replaces EVERYTHING BETWEEN THE /*__*/ MARKERS with the actual
-// tagged version before building, so don't move them.  Using the comment
-// markers enables recovery if someone commits a string other than "HEAD" by
-// accident. git's `ident` attribute doesn't use tag names and `filter` looks
-// more complex than it's worth.
-define constant $server-version :: <string> = /*__*/ "HEAD" /*__*/;
+// The Makefile replaces this string with Git version info before building.
+define constant $server-version :: <string> = "_NO_VERSION_SET_";
 
 // This is needed to handle sockets shutdown.
 define variable *exiting-application* = #f;


### PR DESCRIPTION
The --unify flag still doesn't quite work because libgc.so can't be found.