### PR TITLE
examples: Add http-client-demo

### DIFF
--- a/examples/http-client-demo/http-client-demo.dylan
+++ b/examples/http-client-demo/http-client-demo.dylan
@@ -1,0 +1,23 @@
+Module: http-client-demo
+
+define function main
+    ()
+  let args = application-arguments();
+  let url = "http:/" "/opendylan.org";  // https://github.com/dylan-lang/dylan-emacs-support/issues/27
+  select (args.size)
+    0 => #f;
+    1 => url := args[0];
+    otherwise =>
+      format-out("Usage: %s [URL]\n", application-name());
+  end;
+  format-out("Doing HTTP GET on URL %s...\n\n", url);
+  force-out();
+  block ()
+    start-sockets();
+    http-get(url, stream: *standard-output*);
+  cleanup
+    force-out();
+  end;
+end function;
+
+main();

--- a/examples/http-client-demo/http-client-demo.lid
+++ b/examples/http-client-demo/http-client-demo.lid
@@ -1,0 +1,4 @@
+Library: http-client-demo
+Files: library.dylan
+       http-client-demo.dylan
+Target-Type: executable

--- a/examples/http-client-demo/library.dylan
+++ b/examples/http-client-demo/library.dylan
@@ -1,0 +1,17 @@
+Module: dylan-user
+Synopsis: Module and library definition for simple executable application
+
+define library http-client-demo
+  use common-dylan;
+  use http-client;
+  use io, import: { format-out, standard-io };
+  use network;
+end library;
+
+define module http-client-demo
+  use common-dylan;
+  use format-out;
+  use http-client;
+  use sockets;
+  use standard-io;
+end module;


### PR DESCRIPTION
Demonstrates use of start-sockets and http-get. Used it for testing #7.